### PR TITLE
Mac setup overhaul: system defaults, gh auth, two-phase flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Mac Setup
 
-새 Mac에 개인/업무 환경을 단 한 번에 셋업.
-대부분 비대면으로 진행되고, 사람 손길이 필요한 단계는 마지막에 한 번에 모아둠.
-
 ## Personal Setup
 
 ```bash
@@ -23,29 +20,3 @@ curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/setup.sh -o setu
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/work_setup.sh -o work_setup.sh && \
 bash work_setup.sh
 ```
-
-## 스크립트 구성
-
-| 파일 | 역할 |
-|---|---|
-| `common.sh` | sudo 캐시, caffeinate, Xcode CLT, Homebrew |
-| `setup.sh` | 개인용: CLI/GUI 앱, mise + 런타임, Python, Colima, Rectangle, SSH key |
-| `system_setup.sh` | macOS 시스템 설정 (단축키, 키보드/마우스 속도, Dock, sleep, 기본 브라우저) |
-| `interactive_setup.sh` | 사람 손길 필요한 마지막 단계 (Rectangle accessibility, GitHub OTP 로그인) |
-| `work_setup.sh` | `setup.sh` + Claude Code, Okta Verify |
-
-## 진행 흐름
-
-1. 비대면 단계: Homebrew, 모든 brew 설치, mise 런타임, 시스템 설정 등 자동 진행
-2. **알림 + 벨이 울리면** 돌아와서 마지막 인터랙티브 단계 처리:
-   - Rectangle accessibility 토글 (시스템 설정에서 클릭)
-   - GitHub 브라우저 OTP 로그인 (한 번)
-3. 끝
-
-## 주요 시스템 설정
-
-- 키 반복 속도: 슬라이더 양 끝 (`KeyRepeat=2`, `InitialKeyRepeat=15`) — **로그아웃 후 적용**
-- 마우스/트랙패드 속도: `2.0` (slider 끝에서 ~3칸)
-- Cmd+Space → 입력 소스 변경 / Ctrl+Space → Spotlight
-- AC 슬립 비활성화 (`pmset -c sleep 0`) — 백그라운드 작업 유지
-- Dock: Calendar 만 남김, 자동 숨김

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Mac Setup
 
+새 Mac에 개인/업무 환경을 단 한 번에 셋업.
+대부분 비대면으로 진행되고, 사람 손길이 필요한 단계는 마지막에 한 번에 모아둠.
+
 ## Personal Setup
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/common.sh -o common.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/system_setup.sh -o system_setup.sh && \
+curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/interactive_setup.sh -o interactive_setup.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/setup.sh -o setup.sh && \
 bash setup.sh
 ```
@@ -14,7 +18,34 @@ bash setup.sh
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/common.sh -o common.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/system_setup.sh -o system_setup.sh && \
+curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/interactive_setup.sh -o interactive_setup.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/setup.sh -o setup.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/work_setup.sh -o work_setup.sh && \
 bash work_setup.sh
 ```
+
+## 스크립트 구성
+
+| 파일 | 역할 |
+|---|---|
+| `common.sh` | sudo 캐시, caffeinate, Xcode CLT, Homebrew |
+| `setup.sh` | 개인용: CLI/GUI 앱, mise + 런타임, Python, Colima, Rectangle, SSH key |
+| `system_setup.sh` | macOS 시스템 설정 (단축키, 키보드/마우스 속도, Dock, sleep, 기본 브라우저) |
+| `interactive_setup.sh` | 사람 손길 필요한 마지막 단계 (Rectangle accessibility, GitHub OTP 로그인) |
+| `work_setup.sh` | `setup.sh` + Claude Code, Okta Verify |
+
+## 진행 흐름
+
+1. 비대면 단계: Homebrew, 모든 brew 설치, mise 런타임, 시스템 설정 등 자동 진행
+2. **알림 + 벨이 울리면** 돌아와서 마지막 인터랙티브 단계 처리:
+   - Rectangle accessibility 토글 (시스템 설정에서 클릭)
+   - GitHub 브라우저 OTP 로그인 (한 번)
+3. 끝
+
+## 주요 시스템 설정
+
+- 키 반복 속도: 슬라이더 양 끝 (`KeyRepeat=2`, `InitialKeyRepeat=15`) — **로그아웃 후 적용**
+- 마우스/트랙패드 속도: `2.0` (slider 끝에서 ~3칸)
+- Cmd+Space → 입력 소스 변경 / Ctrl+Space → Spotlight
+- AC 슬립 비활성화 (`pmset -c sleep 0`) — 백그라운드 작업 유지
+- Dock: Calendar 만 남김, 자동 숨김

--- a/common.sh
+++ b/common.sh
@@ -10,8 +10,8 @@ set -e
 # ============================================
 echo "🔐 sudo 비밀번호 입력 (이후 자동 진행됨)..."
 sudo -v
-# sudo 타임아웃 방지
-while true; do sudo -n true; sleep 60; kill -0 "$" || exit; done 2>/dev/null &
+# sudo 타임아웃 방지 — 부모(스크립트) 프로세스가 끝나면 같이 종료
+while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 
 # ============================================
 # Sleep 방지 (caffeinate)

--- a/common.sh
+++ b/common.sh
@@ -35,6 +35,17 @@ brew_install_cask() {
     brew list --cask "$1" &>/dev/null || brew install --cask "$1"
 }
 
+# 다운받아 실행한 .sh 파일들을 끝나면 정리
+# git 체크아웃에서 돌릴 때는 작업 트리를 건드리면 안 되므로 스킵
+cleanup_downloads() {
+    local dir="$1"
+    if git -C "$dir" rev-parse --is-inside-work-tree &>/dev/null; then
+        return 0
+    fi
+    echo "🧹 Cleaning up downloaded scripts..."
+    rm -f "$dir"/{common,system_setup,interactive_setup,setup,work_setup}.sh
+}
+
 # ============================================
 # Xcode Command Line Tools
 # ============================================

--- a/interactive_setup.sh
+++ b/interactive_setup.sh
@@ -16,18 +16,9 @@ osascript -e 'display notification "Setup이 사람 손길을 기다립니다" w
 printf '\a'
 
 # ============================================
-# 기본 브라우저 (macOS 대화상자 → "Use Chrome" 클릭)
-# ============================================
-echo "🌐 Setting Chrome as default browser..."
-echo "  ↳ macOS 대화상자가 뜨면 'Use Chrome' 클릭"
-defaultbrowser chrome
-echo "✅ Default browser configured"
-
-# ============================================
 # GitHub Auth + SSH Key
 # - 브라우저에서 OTP 한 번 입력하면 끝
 # ============================================
-echo ""
 echo "🐙 GitHub authentication..."
 set +e
 if ! gh auth status &>/dev/null; then

--- a/interactive_setup.sh
+++ b/interactive_setup.sh
@@ -16,16 +16,6 @@ osascript -e 'display notification "Setup이 사람 손길을 기다립니다" w
 printf '\a'
 
 # ============================================
-# Rectangle Accessibility 권한
-# - Rectangle 은 setup.sh 에서 이미 실행되어 있음
-# - macOS TCC는 SIP 때문에 사용자 클릭 없이 권한을 줄 수 없으므로
-#   Privacy → Accessibility 패널을 열어 사용자가 토글 한 번 켜면 끝
-# ============================================
-echo "📐 Rectangle accessibility..."
-echo "  ↳ Privacy → Accessibility 에서 Rectangle 토글을 켜주세요."
-open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
-
-# ============================================
 # GitHub Auth + SSH Key
 # - 브라우저에서 OTP 한 번 입력하면 끝
 # ============================================

--- a/interactive_setup.sh
+++ b/interactive_setup.sh
@@ -16,6 +16,17 @@ osascript -e 'display notification "Setup이 사람 손길을 기다립니다" w
 printf '\a'
 
 # ============================================
+# Rectangle Accessibility 권한
+# - macOS TCC는 사용자 클릭 없이 권한을 줄 수 없음 (SIP)
+# - 그래서 Rectangle 실행해서 OS 다이얼로그 띄우고 시스템 설정 패널을 열어줌
+# - 사용자는 패널의 Rectangle 토글 한 번 켜면 끝
+# ============================================
+echo "📐 Rectangle accessibility..."
+echo "  ↳ 시스템 설정 패널이 열립니다 — Rectangle 토글을 켜주세요."
+open -a Rectangle 2>/dev/null
+open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+
+# ============================================
 # GitHub Auth + SSH Key
 # - 브라우저에서 OTP 한 번 입력하면 끝
 # ============================================

--- a/interactive_setup.sh
+++ b/interactive_setup.sh
@@ -21,9 +21,14 @@ printf '\a'
 # ============================================
 echo "🐙 GitHub authentication..."
 set +e
+GH_SCOPE="admin:public_key"
 if ! gh auth status &>/dev/null; then
     echo "  ↳ 브라우저가 열립니다. OTP를 복사해 GitHub에 입력하세요."
-    gh auth login --git-protocol ssh --web --hostname github.com --scopes admin:public_key
+    gh auth login --git-protocol ssh --web --hostname github.com --scopes "$GH_SCOPE"
+elif ! gh auth status 2>&1 | grep -q "$GH_SCOPE"; then
+    # 이미 로그인은 됐지만 SSH 키 등록 스코프가 없음 — 브라우저로 갱신
+    echo "  ↳ 기존 토큰에 $GH_SCOPE 스코프 추가가 필요합니다. 브라우저로 갱신..."
+    gh auth refresh -h github.com -s "$GH_SCOPE"
 fi
 
 SSH_KEY="$HOME/.ssh/id_ed25519"

--- a/interactive_setup.sh
+++ b/interactive_setup.sh
@@ -17,13 +17,12 @@ printf '\a'
 
 # ============================================
 # Rectangle Accessibility 권한
-# - macOS TCC는 사용자 클릭 없이 권한을 줄 수 없음 (SIP)
-# - 그래서 Rectangle 실행해서 OS 다이얼로그 띄우고 시스템 설정 패널을 열어줌
-# - 사용자는 패널의 Rectangle 토글 한 번 켜면 끝
+# - Rectangle 은 setup.sh 에서 이미 실행되어 있음
+# - macOS TCC는 SIP 때문에 사용자 클릭 없이 권한을 줄 수 없으므로
+#   Privacy → Accessibility 패널을 열어 사용자가 토글 한 번 켜면 끝
 # ============================================
 echo "📐 Rectangle accessibility..."
-echo "  ↳ 시스템 설정 패널이 열립니다 — Rectangle 토글을 켜주세요."
-open -a Rectangle 2>/dev/null
+echo "  ↳ Privacy → Accessibility 에서 Rectangle 토글을 켜주세요."
 open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
 
 # ============================================

--- a/interactive_setup.sh
+++ b/interactive_setup.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# ============================================
+# Interactive Setup (사람 필요한 마지막 단계)
+# - 비대면 단계는 모두 끝낸 뒤 마지막에 호출
+# - 호출 위치: setup.sh / work_setup.sh 의 맨 끝
+# ============================================
+
+echo ""
+echo "============================================"
+echo "✋ 이제 사람이 필요한 마지막 단계"
+echo "============================================"
+echo ""
+
+# 알림 + 터미널 벨 (다른 작업 중이면 돌아오라는 신호)
+osascript -e 'display notification "Setup이 사람 손길을 기다립니다" with title "Mac Setup" sound name "Glass"' 2>/dev/null
+printf '\a'
+
+# ============================================
+# 기본 브라우저 (macOS 대화상자 → "Use Chrome" 클릭)
+# ============================================
+echo "🌐 Setting Chrome as default browser..."
+echo "  ↳ macOS 대화상자가 뜨면 'Use Chrome' 클릭"
+defaultbrowser chrome
+echo "✅ Default browser configured"
+
+# ============================================
+# GitHub Auth + SSH Key
+# - 브라우저에서 OTP 한 번 입력하면 끝
+# ============================================
+echo ""
+echo "🐙 GitHub authentication..."
+set +e
+if ! gh auth status &>/dev/null; then
+    echo "  ↳ 브라우저가 열립니다. OTP를 복사해 GitHub에 입력하세요."
+    gh auth login --git-protocol ssh --web --hostname github.com --scopes admin:public_key
+fi
+
+SSH_KEY="$HOME/.ssh/id_ed25519"
+if [[ -f "$SSH_KEY.pub" ]]; then
+    LOCAL_PUB=$(awk '{print $2}' "$SSH_KEY.pub")
+    if ! gh ssh-key list 2>/dev/null | grep -qF "$LOCAL_PUB"; then
+        echo "🔑 GitHub에 SSH 키 등록..."
+        gh ssh-key add "$SSH_KEY.pub" --title "$(hostname)-$(date +%Y%m%d)"
+    fi
+fi
+set -e
+echo "✅ GitHub ready"

--- a/setup.sh
+++ b/setup.sh
@@ -43,10 +43,15 @@ if [[ ! -f "$SSH_KEY" ]]; then
     ssh-keygen -t ed25519 -f "$SSH_KEY" -N "" -C "$(whoami)@$(hostname)"
 fi
 
+# github.com host key를 known_hosts에 미리 등록 (첫 push 프롬프트 방지)
+if ! ssh-keygen -F github.com -f "$HOME/.ssh/known_hosts" &>/dev/null; then
+    ssh-keyscan -t ed25519,rsa github.com >> "$HOME/.ssh/known_hosts" 2>/dev/null
+fi
+
 set +e
 if ! gh auth status &>/dev/null; then
     echo "🌐 GitHub 로그인 — 브라우저가 열립니다. 한 번만 로그인하면 됩니다."
-    gh auth login --git-protocol ssh --web --hostname github.com
+    gh auth login --git-protocol ssh --web --hostname github.com --scopes admin:public_key
 fi
 
 LOCAL_PUB=$(awk '{print $2}' "$SSH_KEY.pub")

--- a/setup.sh
+++ b/setup.sh
@@ -69,7 +69,9 @@ defaults write com.knollsoft.Rectangle launchOnLogin -bool true
 defaults write com.knollsoft.Rectangle SUEnableAutomaticChecks -bool true
 defaults write com.knollsoft.Rectangle hideMenubarIcon -bool false
 defaults write com.knollsoft.Rectangle subsequentExecutionMode -int 0
-echo "✅ Rectangle configured"
+# 첫 실행 → macOS의 Accessibility 권한 다이얼로그가 백그라운드에 뜸
+open -a Rectangle
+echo "✅ Rectangle launched (Accessibility 토글은 마지막 단계에서)"
 
 # ============================================
 # Vim Settings

--- a/setup.sh
+++ b/setup.sh
@@ -69,6 +69,13 @@ defaults write com.knollsoft.Rectangle launchOnLogin -bool true
 defaults write com.knollsoft.Rectangle SUEnableAutomaticChecks -bool true
 defaults write com.knollsoft.Rectangle hideMenubarIcon -bool false
 defaults write com.knollsoft.Rectangle subsequentExecutionMode -int 0
+
+# macOS Sequoia 내장 타일링 비활성화 (Rectangle 과 충돌 방지)
+defaults write com.apple.WindowManager EnableTilingByEdgeDrag -bool false
+defaults write com.apple.WindowManager EnableTopTilingByEdgeDrag -bool false
+defaults write com.apple.WindowManager EnableTilingOptionAccelerator -bool false
+defaults write com.apple.WindowManager EnableTiledWindowMargins -bool false
+
 # 첫 실행 → macOS의 Accessibility 권한 다이얼로그가 백그라운드에 뜸
 open -a Rectangle
 echo "✅ Rectangle launched (Accessibility 토글은 마지막 단계에서)"

--- a/setup.sh
+++ b/setup.sh
@@ -30,37 +30,20 @@ brew_install gh
 echo "✅ CLI tools ready"
 
 # ============================================
-# GitHub Auth + SSH Key (자동화)
-# - SSH 키 자동 생성
-# - 브라우저로 한 번 로그인하면 GitHub에 키 등록까지 자동
+# SSH Key (비대면 준비 — 인증/등록은 마지막 interactive 단계에서)
 # ============================================
-echo "🐙 Setting up GitHub authentication..."
+echo "🔑 Preparing SSH key..."
 SSH_KEY="$HOME/.ssh/id_ed25519"
 if [[ ! -f "$SSH_KEY" ]]; then
-    echo "🔑 SSH 키 생성..."
     mkdir -p "$HOME/.ssh"
     chmod 700 "$HOME/.ssh"
     ssh-keygen -t ed25519 -f "$SSH_KEY" -N "" -C "$(whoami)@$(hostname)"
 fi
-
-# github.com host key를 known_hosts에 미리 등록 (첫 push 프롬프트 방지)
+# github.com host key 사전 등록 (첫 push 프롬프트 방지)
 if ! ssh-keygen -F github.com -f "$HOME/.ssh/known_hosts" &>/dev/null; then
     ssh-keyscan -t ed25519,rsa github.com >> "$HOME/.ssh/known_hosts" 2>/dev/null
 fi
-
-set +e
-if ! gh auth status &>/dev/null; then
-    echo "🌐 GitHub 로그인 — 브라우저가 열립니다. 한 번만 로그인하면 됩니다."
-    gh auth login --git-protocol ssh --web --hostname github.com --scopes admin:public_key
-fi
-
-LOCAL_PUB=$(awk '{print $2}' "$SSH_KEY.pub")
-if ! gh ssh-key list 2>/dev/null | grep -qF "$LOCAL_PUB"; then
-    echo "🔑 GitHub에 SSH 키 등록..."
-    gh ssh-key add "$SSH_KEY.pub" --title "$(hostname)-$(date +%Y%m%d)"
-fi
-set -e
-echo "✅ GitHub ready"
+echo "✅ SSH key ready"
 
 # ============================================
 # GUI Applications
@@ -129,19 +112,25 @@ fi
 echo "✅ Colima ready"
 
 # ============================================
-# macOS System Settings
+# macOS System Settings (비대면)
 # ============================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/system_setup.sh"
 
 # ============================================
-# Done!
+# Interactive Section (사람 필요)
+# - work_setup.sh 처럼 더 뒤에 단계가 남아있는 호출자는
+#   INTERACTIVE_DEFERRED=1 로 스킵하고 자기 끝에서 직접 source
 # ============================================
-echo ""
-echo "============================================"
-echo "🎉 Setup Complete!"
-echo "============================================"
-echo ""
-echo "새 터미널을 열거나: source ~/.zshrc"
-echo "설치된 런타임 확인: mise list"
-echo ""
+if [[ -z "$INTERACTIVE_DEFERRED" ]]; then
+    source "$SCRIPT_DIR/interactive_setup.sh"
+
+    echo ""
+    echo "============================================"
+    echo "🎉 Setup Complete!"
+    echo "============================================"
+    echo ""
+    echo "새 터미널을 열거나: source ~/.zshrc"
+    echo "설치된 런타임 확인: mise list"
+    echo ""
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,36 @@ brew_install defaultbrowser
 brew_install docker
 brew_install docker-compose
 brew_install colima
+brew_install gh
 echo "✅ CLI tools ready"
+
+# ============================================
+# GitHub Auth + SSH Key (자동화)
+# - SSH 키 자동 생성
+# - 브라우저로 한 번 로그인하면 GitHub에 키 등록까지 자동
+# ============================================
+echo "🐙 Setting up GitHub authentication..."
+SSH_KEY="$HOME/.ssh/id_ed25519"
+if [[ ! -f "$SSH_KEY" ]]; then
+    echo "🔑 SSH 키 생성..."
+    mkdir -p "$HOME/.ssh"
+    chmod 700 "$HOME/.ssh"
+    ssh-keygen -t ed25519 -f "$SSH_KEY" -N "" -C "$(whoami)@$(hostname)"
+fi
+
+set +e
+if ! gh auth status &>/dev/null; then
+    echo "🌐 GitHub 로그인 — 브라우저가 열립니다. 한 번만 로그인하면 됩니다."
+    gh auth login --git-protocol ssh --web --hostname github.com
+fi
+
+LOCAL_PUB=$(awk '{print $2}' "$SSH_KEY.pub")
+if ! gh ssh-key list 2>/dev/null | grep -qF "$LOCAL_PUB"; then
+    echo "🔑 GitHub에 SSH 키 등록..."
+    gh ssh-key add "$SSH_KEY.pub" --title "$(hostname)-$(date +%Y%m%d)"
+fi
+set -e
+echo "✅ GitHub ready"
 
 # ============================================
 # GUI Applications

--- a/setup.sh
+++ b/setup.sh
@@ -136,10 +136,10 @@ source "$SCRIPT_DIR/system_setup.sh"
 
 # ============================================
 # Interactive Section (사람 필요)
-# - work_setup.sh 처럼 더 뒤에 단계가 남아있는 호출자는
-#   INTERACTIVE_DEFERRED=1 로 스킵하고 자기 끝에서 직접 source
+# - 직접 실행 (./setup.sh) 일 때만 진행
+# - source 로 불려왔으면 (work_setup.sh 등) 호출자가 자기 끝에서 처리
 # ============================================
-if [[ -z "$INTERACTIVE_DEFERRED" ]]; then
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     source "$SCRIPT_DIR/interactive_setup.sh"
 
     echo ""
@@ -150,4 +150,6 @@ if [[ -z "$INTERACTIVE_DEFERRED" ]]; then
     echo "새 터미널을 열거나: source ~/.zshrc"
     echo "설치된 런타임 확인: mise list"
     echo ""
+
+    cleanup_downloads "$SCRIPT_DIR"
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -57,6 +57,21 @@ brew_install_cask postman
 echo "✅ Applications ready"
 
 # ============================================
+# Rectangle (Recommended preset)
+# - alternateDefaultShortcuts=false → "Recommended" 단축키 사용
+# - launchOnLogin=true → 로그인 시 자동 시작
+# - 첫 실행 환영 다이얼로그 스킵
+# - Accessibility 권한은 interactive_setup.sh 에서 처리
+# ============================================
+echo "📐 Configuring Rectangle (Recommended preset)..."
+defaults write com.knollsoft.Rectangle alternateDefaultShortcuts -bool false
+defaults write com.knollsoft.Rectangle launchOnLogin -bool true
+defaults write com.knollsoft.Rectangle SUEnableAutomaticChecks -bool true
+defaults write com.knollsoft.Rectangle hideMenubarIcon -bool false
+defaults write com.knollsoft.Rectangle subsequentExecutionMode -int 0
+echo "✅ Rectangle configured"
+
+# ============================================
 # Vim Settings
 # ============================================
 echo "📝 Setting up Vim..."

--- a/setup.sh
+++ b/setup.sh
@@ -117,7 +117,10 @@ echo "✅ Python tools ready"
 echo "🐳 Checking Colima..."
 if colima status 2>&1 | grep -q "not running\|not exist"; then
     echo "Starting Colima..."
-    colima start
+    # set -e 하에서 colima start 실패가 setup 전체를 죽이지 않도록 격리
+    if ! colima start; then
+        echo "⚠️ Colima 시작 실패 — 나중에 'colima start' 수동 실행"
+    fi
 fi
 echo "✅ Colima ready"
 

--- a/setup.sh
+++ b/setup.sh
@@ -57,28 +57,14 @@ brew_install_cask postman
 echo "✅ Applications ready"
 
 # ============================================
-# Rectangle (Recommended preset)
-# - alternateDefaultShortcuts=false → "Recommended" 단축키 사용
-# - launchOnLogin=true → 로그인 시 자동 시작
-# - 첫 실행 환영 다이얼로그 스킵
-# - Accessibility 권한은 interactive_setup.sh 에서 처리
+# Rectangle
+# - launchOnLogin 만 미리 설정 (환영 다이얼로그에 없어서 까먹기 쉬움)
+# - 단축키 프리셋, 타일링 끄기, Accessibility 는 첫 실행 UI 에서 안내
 # ============================================
-echo "📐 Configuring Rectangle (Recommended preset)..."
-defaults write com.knollsoft.Rectangle alternateDefaultShortcuts -bool false
+echo "📐 Launching Rectangle..."
 defaults write com.knollsoft.Rectangle launchOnLogin -bool true
-defaults write com.knollsoft.Rectangle SUEnableAutomaticChecks -bool true
-defaults write com.knollsoft.Rectangle hideMenubarIcon -bool false
-defaults write com.knollsoft.Rectangle subsequentExecutionMode -int 0
-
-# macOS Sequoia 내장 타일링 비활성화 (Rectangle 과 충돌 방지)
-defaults write com.apple.WindowManager EnableTilingByEdgeDrag -bool false
-defaults write com.apple.WindowManager EnableTopTilingByEdgeDrag -bool false
-defaults write com.apple.WindowManager EnableTilingOptionAccelerator -bool false
-defaults write com.apple.WindowManager EnableTiledWindowMargins -bool false
-
-# 첫 실행 → macOS의 Accessibility 권한 다이얼로그가 백그라운드에 뜸
 open -a Rectangle
-echo "✅ Rectangle launched (Accessibility 토글은 마지막 단계에서)"
+echo "✅ Rectangle launched"
 
 # ============================================
 # Vim Settings

--- a/system_setup.sh
+++ b/system_setup.sh
@@ -66,6 +66,27 @@ defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 60 \
 echo "✅ Keyboard shortcuts ready"
 
 # ============================================
+# Keyboard Repeat Speed (키 반복 속도)
+# - KeyRepeat: 키 반복 속도 (작을수록 빠름, 슬라이더 최대 = 2)
+# - InitialKeyRepeat: 첫 반복까지 딜레이 (작을수록 짧음, 슬라이더 최소 = 15)
+# - 적용: 로그아웃 후 다시 로그인
+# ============================================
+echo "⌨️ Setting keyboard repeat to max speed..."
+defaults write -g KeyRepeat -int 2
+defaults write -g InitialKeyRepeat -int 15
+echo "✅ Keyboard repeat configured (logout 필요)"
+
+# ============================================
+# Mouse / Trackpad Tracking Speed
+# - 슬라이더 끝에서 약 3칸 남긴 위치 (~2.0)
+# - 마우스, 트랙패드 모두 동일 값
+# ============================================
+echo "🖱️ Setting tracking speed..."
+defaults write -g com.apple.mouse.scaling -float 2.0
+defaults write -g com.apple.trackpad.scaling -float 2.0
+echo "✅ Tracking speed configured"
+
+# ============================================
 # Dock Settings (Dock 설정)
 # - Finder, Calendar 만 남기고 나머지 제거
 # - Auto-hide 활성화

--- a/system_setup.sh
+++ b/system_setup.sh
@@ -5,8 +5,14 @@
 
 echo "⚙️ Configuring macOS settings..."
 
-# 참고: defaultbrowser 는 macOS 대화상자가 떠서 사람 손길이 필요하므로
-# interactive_setup.sh 로 옮겨졌음
+# ============================================
+# Default Browser
+# - 명령 자체는 즉시 리턴 (non-blocking)
+# - macOS 대화상자가 백그라운드에 뜸 → 시간될 때 "Use Chrome" 클릭
+# ============================================
+echo "🌐 Setting Chrome as default browser..."
+defaultbrowser chrome
+echo "✅ Chrome set as default (다이얼로그 클릭 필요)"
 
 # ============================================
 # Keyboard Shortcuts (키보드 단축키 설정)

--- a/system_setup.sh
+++ b/system_setup.sh
@@ -77,6 +77,14 @@ defaults write -g InitialKeyRepeat -int 15
 echo "✅ Keyboard repeat configured (logout 필요)"
 
 # ============================================
+# Screensaver Idle Time (움직임 없을 때 화면보호기)
+# - 1분 후 시작
+# ============================================
+echo "🖼️ Setting screensaver idle to 1 minute..."
+defaults -currentHost write com.apple.screensaver idleTime -int 60
+echo "✅ Screensaver idle configured"
+
+# ============================================
 # Prevent Sleep on AC Power
 # - "Prevent automatic sleeping when the display is off"에 해당
 # - 백그라운드 작업 항상 돌리려고 비활성화

--- a/system_setup.sh
+++ b/system_setup.sh
@@ -77,6 +77,15 @@ defaults write -g InitialKeyRepeat -int 15
 echo "✅ Keyboard repeat configured (logout 필요)"
 
 # ============================================
+# Prevent Sleep on AC Power
+# - "Prevent automatic sleeping when the display is off"에 해당
+# - 백그라운드 작업 항상 돌리려고 비활성화
+# ============================================
+echo "🔋 Disabling automatic sleep on power adapter..."
+sudo pmset -c sleep 0
+echo "✅ Sleep on AC disabled"
+
+# ============================================
 # Mouse / Trackpad Tracking Speed
 # - 슬라이더 끝에서 약 3칸 남긴 위치 (~2.0)
 # - 마우스, 트랙패드 모두 동일 값

--- a/system_setup.sh
+++ b/system_setup.sh
@@ -5,14 +5,8 @@
 
 echo "⚙️ Configuring macOS settings..."
 
-# ============================================
-# Default Browser (수동 인터랙션 필요)
-# - macOS 시스템 대화상자가 뜨면 Tab+Space로 확인
-# - 스크립트는 멈추지 않고 계속 진행됨
-# ============================================
-echo "🌐 Setting Chrome as default browser..."
-defaultbrowser chrome
-echo "✅ Chrome set as default"
+# 참고: defaultbrowser 는 macOS 대화상자가 떠서 사람 손길이 필요하므로
+# interactive_setup.sh 로 옮겨졌음
 
 # ============================================
 # Keyboard Shortcuts (키보드 단축키 설정)

--- a/work_setup.sh
+++ b/work_setup.sh
@@ -3,10 +3,11 @@ echo "💼 Work Mac Setup Starting..."
 
 # ============================================
 # Personal Setup (includes common.sh)
-# - INTERACTIVE_DEFERRED=1 로 인터랙티브 단계는 이 스크립트 끝까지 미룸
+# - source 로 불러서 setup.sh 안의 인터랙티브 단계는 자동으로 스킵됨
+#   (BASH_SOURCE 체크로 직접 실행일 때만 동작)
 # ============================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-INTERACTIVE_DEFERRED=1 source "$SCRIPT_DIR/setup.sh"
+source "$SCRIPT_DIR/setup.sh"
 
 # ============================================
 # Claude Code
@@ -36,3 +37,5 @@ echo "🎉 Work Setup Complete!"
 echo "- TODO: Install exosphere"
 echo "============================================"
 echo ""
+
+cleanup_downloads "$SCRIPT_DIR"

--- a/work_setup.sh
+++ b/work_setup.sh
@@ -3,9 +3,10 @@ echo "💼 Work Mac Setup Starting..."
 
 # ============================================
 # Personal Setup (includes common.sh)
+# - INTERACTIVE_DEFERRED=1 로 인터랙티브 단계는 이 스크립트 끝까지 미룸
 # ============================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/setup.sh"
+INTERACTIVE_DEFERRED=1 source "$SCRIPT_DIR/setup.sh"
 
 # ============================================
 # Claude Code
@@ -20,6 +21,11 @@ echo "✅ Claude Code ready"
 echo "🔐 Installing Okta Verify..."
 brew_install_cask okta-verify
 echo "✅ Okta Verify ready"
+
+# ============================================
+# Interactive Section (사람 필요한 단계 한 번에)
+# ============================================
+source "$SCRIPT_DIR/interactive_setup.sh"
 
 # ============================================
 # Done!


### PR DESCRIPTION
## Summary

### System defaults (system_setup.sh)
- Keyboard repeat at slider extremes (`KeyRepeat=2`, `InitialKeyRepeat=15`)
- Mouse / trackpad scaling at 2.0 (~3 ticks from end)
- Screensaver after 1 minute idle
- Disable AC sleep so background work keeps running (`pmset -c sleep 0`)

### GitHub auth automation
- Install `gh`, generate ed25519 SSH key, pre-add `github.com` to `known_hosts`
- One web OTP login provisions everything: `gh auth login --git-protocol ssh --web --scopes admin:public_key`
- Auto-upload public key via `gh ssh-key add`
- On re-runs: detects missing `admin:public_key` scope on existing token and runs `gh auth refresh` instead of silently skipping

### Rectangle
- Pre-set `launchOnLogin=true` (the one setting Rectangle's welcome dialog doesn't surface)
- Launch Rectangle during the unattended phase so macOS's accessibility dialog is already waiting when the user returns

### Two-phase flow
- New `interactive_setup.sh` holds the only step that actually blocks on a human (GitHub OTP login)
- `setup.sh` and `work_setup.sh` run all unattended work first, then call interactive at the very end with a macOS notification + terminal bell
- Standard `[[ "${BASH_SOURCE[0]}" == "${0}" ]]` check (no env-var trick) makes setup.sh skip interactive when sourced from work_setup.sh — that wrapper handles its own tail
- `cleanup_downloads()` removes the curl-downloaded scripts on exit, but skips when running inside a git checkout

### Latent bug fixes (caught during review)
- `common.sh`: sudo keep-alive used `"$"` (literal `$`) instead of `"$$"`, so the parent-PID check always failed silently and the loop orphaned past script exit
- `setup.sh`: wrap `colima start` so a transient failure doesn't kill the whole script under `set -e`

## Test plan
- [x] `defaults read -g KeyRepeat / InitialKeyRepeat` → `2` / `15`
- [x] `defaults read -g com.apple.{mouse,trackpad}.scaling` → `2`
- [x] `defaults -currentHost read com.apple.screensaver idleTime` → `60`
- [x] `brew install gh` succeeds; `gh auth login` web flow completes
- [x] `gh ssh-key add` uploads the generated key (verified the wrong-scope failure mode and the fix)
- [x] `ssh -T git@github.com` authenticates without host-key prompt
- [x] `git push` over SSH succeeds end-to-end
- [x] `BASH_SOURCE`-based interactive gating: equal=yes when run directly, equal=no when sourced
- [x] `$$` propagates into backgrounded subshells (sudo keep-alive fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)