### PR TITLE
Add CI: shellcheck + macOS bash 3.2 parse + macOS full smoke run

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches: [master]
 
+# 같은 브랜치에서 푸시가 연달아 일어나면 직전 실행 취소 — macOS 분량 절약
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
@@ -26,3 +31,21 @@ jobs:
             echo "Checking $f..."
             /bin/bash -n "$f"
           done
+
+  smoke-macos:
+    # 진짜 검증: fresh-ish macOS 러너에서 setup.sh 를 실제로 돌려서
+    # brew 패키지 이름 오타, 사라진 cask, mise 식별자 변경, defaults 키 변경 등
+    # lint 가 못 잡는 회귀를 끝까지 잡는다.
+    # SETUP_NONINTERACTIVE=1 로 gh auth 등 인터랙티브 단계와 colima start 만 스킵.
+    runs-on: macos-latest
+    timeout-minutes: 40
+    env:
+      SETUP_NONINTERACTIVE: "1"
+      # GHA 러너에는 Homebrew/Xcode CLT 가 이미 깔려있어 setup.sh 가 알아서 스킵
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+      HOMEBREW_NO_ENV_HINTS: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run setup.sh non-interactively
+        run: ./setup.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        # SC2016 제외: add_to_zshrc 'eval "$(...)"' 처럼 리터럴 그대로 .zshrc 에 써야 하는 케이스가 의도된 동작
+        run: shellcheck --severity=warning --exclude=SC2016 *.sh
+
+  syntax-check-macos:
+    # macOS 기본 bash 는 3.2 — bash 4+ 기능을 무심코 쓰면 fresh mac 에서만 깨짐
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse-check with system bash (3.2)
+        run: |
+          /bin/bash --version
+          for f in *.sh; do
+            echo "Checking $f..."
+            /bin/bash -n "$f"
+          done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,8 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: "1"
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
       HOMEBREW_NO_ENV_HINTS: "1"
+      # mise 가 GitHub API 로 릴리즈 태그 조회 — 미인증은 IP 공유 러너에서 60/h 한도라 금방 걸림
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Run setup.sh non-interactively

--- a/common.sh
+++ b/common.sh
@@ -18,7 +18,7 @@ while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 # ============================================
 caffeinate -disu &
 CAFFEINATE_PID=$!
-trap "kill $CAFFEINATE_PID 2>/dev/null" EXIT
+trap 'kill $CAFFEINATE_PID 2>/dev/null' EXIT
 
 # ============================================
 # Helper Functions

--- a/setup.sh
+++ b/setup.sh
@@ -113,9 +113,12 @@ echo "✅ Python tools ready"
 
 # ============================================
 # Colima (Docker runtime)
+# - SETUP_NONINTERACTIVE: CI 에선 nested-virt 시작이 오래 걸리고 검증 가치도 낮아 스킵
 # ============================================
 echo "🐳 Checking Colima..."
-if colima status 2>&1 | grep -q "not running\|not exist"; then
+if [[ -n "$SETUP_NONINTERACTIVE" ]]; then
+    echo "  ↳ SETUP_NONINTERACTIVE — colima start 스킵"
+elif colima status 2>&1 | grep -q "not running\|not exist"; then
     echo "Starting Colima..."
     # set -e 하에서 colima start 실패가 setup 전체를 죽이지 않도록 격리
     if ! colima start; then
@@ -136,7 +139,11 @@ source "$SCRIPT_DIR/system_setup.sh"
 # - source 로 불려왔으면 (work_setup.sh 등) 호출자가 자기 끝에서 처리
 # ============================================
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    source "$SCRIPT_DIR/interactive_setup.sh"
+    if [[ -z "$SETUP_NONINTERACTIVE" ]]; then
+        source "$SCRIPT_DIR/interactive_setup.sh"
+    else
+        echo "  ↳ SETUP_NONINTERACTIVE — interactive 단계 스킵"
+    fi
 
     echo ""
     echo "============================================"

--- a/work_setup.sh
+++ b/work_setup.sh
@@ -26,7 +26,11 @@ echo "✅ Okta Verify ready"
 # ============================================
 # Interactive Section (사람 필요한 단계 한 번에)
 # ============================================
-source "$SCRIPT_DIR/interactive_setup.sh"
+if [[ -z "$SETUP_NONINTERACTIVE" ]]; then
+    source "$SCRIPT_DIR/interactive_setup.sh"
+else
+    echo "  ↳ SETUP_NONINTERACTIVE — interactive 단계 스킵"
+fi
 
 # ============================================
 # Done!


### PR DESCRIPTION
## Summary
셋업 스크립트는 새 맥에서만 돌리는 특성상 회귀가 늦게 발견됨 → PR 단계에서 자동 검증.

세 단계 검증:

1. **shellcheck (Ubuntu)**: 따옴표 누락, 미정의 변수, trap quoting 같은 **문법 실수** 검출. SC2016 제외 (add_to_zshrc 가 리터럴 `\$(...)` 를 .zshrc 에 써야 하는 의도된 동작).
2. **bash -n on macOS system bash 3.2**: macOS 기본 bash 가 3.2 — bash 4+ 기능을 무심코 쓰면 fresh mac 에서만 깨짐. 시스템 bash 로 parse-check.
3. **smoke-macos: 실제로 setup.sh 끝까지 실행**: lint 가 못 잡는 진짜 회귀 — `brew install` 패키지 이름 오타, 사라진 cask, 변경된 `mise` 식별자, `defaults` 키 변경, gh / pmset 명령어 변경 — 을 GHA macOS 러너에서 실제 실행으로 검증. **이게 진짜 검증.**

CircleCI PR (#9) 의 의도를 살리되 가성비/실효성 모두 더 높은 방식.

## Skip 처리
`SETUP_NONINTERACTIVE=1` 가드로 CI 에서 스킵:
- `interactive_setup.sh` 의 `gh auth login --web`, `gh ssh-key add`, `osascript` 알림 — 사람/브라우저 필요
- `colima start` — nested-virt 시작이 GHA 에서 느리고 그 자체 실패는 스크립트 회귀가 아닌 환경 이슈

`SETUP_NONINTERACTIVE` 가 비어있으면 (=로컬) 평소처럼 인터랙티브 단계까지 모두 동작.

## 부수 변경
- `common.sh:21` SC2064 trap quoting 한 줄 수정 — single quote 으로 늦은 확장. CI 첫 실행 통과용.

## Test plan
- [x] `shellcheck --severity=warning --exclude=SC2016 *.sh` 로컬 통과
- [x] `/bin/bash -n` (3.2) 모든 .sh parse 통과
- [ ] PR CI 세 잡 모두 green 확인 — 특히 smoke-macos 가 실제로 끝까지 돌면서 brew/mise/defaults 가 정상 동작하는지
- [ ] (선택) 일부러 `brew install starshipp` 같은 오타 넣고 push 해서 smoke 가 빨간불 뜨는지 확인