### PR TITLE
Add work Codex MCP setup and append helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: lint
+name: ci
 
 on:
   pull_request:
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run shellcheck
-        # SC2016 제외: add_to_zshrc 'eval "$(...)"' 처럼 리터럴 그대로 .zshrc 에 써야 하는 케이스가 의도된 동작
+        # SC2016 제외: append_line_if_missing 으로 리터럴 그대로 .zshrc 에 써야 하는 케이스가 의도된 동작
         run: shellcheck --severity=warning --exclude=SC2016 *.sh
 
   syntax-check-macos:

--- a/common.sh
+++ b/common.sh
@@ -23,8 +23,30 @@ trap 'kill $CAFFEINATE_PID 2>/dev/null' EXIT
 # ============================================
 # Helper Functions
 # ============================================
-add_to_zshrc() {
-    grep -qF "$1" ~/.zshrc 2>/dev/null || echo "$1" >> ~/.zshrc
+append_block_if_missing() {
+    local file="$1"
+    local marker="$2"
+
+    mkdir -p "$(dirname "$file")"
+    touch "$file"
+
+    if grep -qF "$marker" "$file"; then
+        return 0
+    fi
+
+    if [[ -s "$file" ]]; then
+        printf "\n" >> "$file"
+    fi
+    cat >> "$file"
+}
+
+append_line_if_missing() {
+    local file="$1"
+    local line="$2"
+
+    append_block_if_missing "$file" "$line" <<EOF
+$line
+EOF
 }
 
 brew_install() {
@@ -74,5 +96,5 @@ if ! command -v brew &>/dev/null; then
 fi
 
 eval "$(/opt/homebrew/bin/brew shellenv)"
-add_to_zshrc 'eval "$(/opt/homebrew/bin/brew shellenv)"'
+append_line_if_missing "$HOME/.zshrc" 'eval "$(/opt/homebrew/bin/brew shellenv)"'
 echo "✅ Homebrew ready"

--- a/common.sh
+++ b/common.sh
@@ -57,9 +57,11 @@ brew_install_cask() {
     local cask="$1"
 
     if brew list --cask "$cask" &>/dev/null; then
+        echo "  ↳ Cask $cask already installed"
         return 0
     fi
 
+    echo "  ↳ Installing cask $cask"
     brew install --cask "$cask" || {
         echo "⚠️ Cask $cask install failed. Updating Homebrew and retrying..."
         brew update

--- a/common.sh
+++ b/common.sh
@@ -54,7 +54,17 @@ brew_install() {
 }
 
 brew_install_cask() {
-    brew list --cask "$1" &>/dev/null || brew install --cask "$1"
+    local cask="$1"
+
+    if brew list --cask "$cask" &>/dev/null; then
+        return 0
+    fi
+
+    brew install --cask "$cask" || {
+        echo "⚠️ Cask $cask install failed. Updating Homebrew and retrying..."
+        brew update
+        brew install --cask "$cask"
+    }
 }
 
 # 다운받아 실행한 .sh 파일들을 끝나면 정리

--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ source "$SCRIPT_DIR/common.sh"
 # ============================================
 echo "🚀 Checking Starship..."
 brew_install starship
-add_to_zshrc 'eval "$(starship init zsh)"'
+append_line_if_missing "$HOME/.zshrc" 'eval "$(starship init zsh)"'
 echo "✅ Starship ready"
 
 # ============================================
@@ -80,7 +80,7 @@ echo "✅ Vim ready"
 # ============================================
 echo "🔄 Checking mise..."
 brew_install mise
-add_to_zshrc 'eval "$(mise activate zsh)"'
+append_line_if_missing "$HOME/.zshrc" 'eval "$(mise activate zsh)"'
 eval "$(mise activate bash)"
 
 echo "🐹 Setting up Go..."
@@ -105,9 +105,9 @@ echo "🐍 Setting up Python..."
 brew_install pyenv
 brew_install uv
 
-add_to_zshrc 'export PYENV_ROOT="$HOME/.pyenv"'
-add_to_zshrc '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
-add_to_zshrc 'eval "$(pyenv init -)"'
+append_line_if_missing "$HOME/.zshrc" 'export PYENV_ROOT="$HOME/.pyenv"'
+append_line_if_missing "$HOME/.zshrc" '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
+append_line_if_missing "$HOME/.zshrc" 'eval "$(pyenv init -)"'
 
 echo "✅ Python tools ready"
 

--- a/work_setup.sh
+++ b/work_setup.sh
@@ -24,6 +24,50 @@ brew_install_cask okta-verify
 echo "✅ Okta Verify ready"
 
 # ============================================
+# Codex + Work MCP servers
+# ============================================
+echo "🤖 Installing Codex and MCP tools..."
+brew_install_cask codex
+brew_install mcp-grafana
+
+append_line_if_missing "$HOME/.zshrc" 'export GRAFANA_URL="${GRAFANA_URL:-}"'
+append_line_if_missing "$HOME/.zshrc" 'export GRAFANA_SERVICE_ACCOUNT_TOKEN="${GRAFANA_SERVICE_ACCOUNT_TOKEN:-}"'
+
+append_block_if_missing "$HOME/.codex/config.toml" "[mcp_servers.grafana]" <<'EOF'
+[mcp_servers.grafana]
+command = "/opt/homebrew/bin/mcp-grafana"
+args = []
+env_vars = [
+  "GRAFANA_URL",
+  "GRAFANA_SERVICE_ACCOUNT_TOKEN",
+]
+EOF
+echo "  ↳ Codex MCP 'grafana' configured"
+
+append_block_if_missing "$HOME/.codex/config.toml" "[mcp_servers.datadog]" <<'EOF'
+[mcp_servers.datadog]
+url = "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+EOF
+echo "  ↳ Codex MCP 'datadog' configured"
+
+append_block_if_missing "$HOME/.codex/config.toml" "[mcp_servers.channel-teamchat]" <<'EOF'
+[mcp_servers.channel-teamchat]
+url = "https://cht-teamchat-mcp.dmz.channel.io/mcp"
+EOF
+echo "  ↳ Codex MCP 'channel-teamchat' configured"
+
+echo "  ↳ Grafana reads GRAFANA_URL and GRAFANA_SERVICE_ACCOUNT_TOKEN when Codex starts"
+if [[ -n "$SETUP_NONINTERACTIVE" ]]; then
+    echo "  ↳ SETUP_NONINTERACTIVE — Codex MCP OAuth login 스킵"
+elif command -v codex &>/dev/null; then
+    codex mcp login datadog || echo "⚠️ Datadog MCP login skipped"
+    codex mcp login channel-teamchat || echo "⚠️ Channel Teamchat MCP login skipped"
+else
+    echo "⚠️ codex command not found. Open Codex once, then retry MCP login manually."
+fi
+echo "✅ Codex ready"
+
+# ============================================
 # Interactive Section (사람 필요한 단계 한 번에)
 # ============================================
 if [[ -z "$SETUP_NONINTERACTIVE" ]]; then


### PR DESCRIPTION
## What's changed

- Add `append_block_if_missing` as the common idempotent file helper.
- Add `append_line_if_missing` on top of `append_block_if_missing`, and replace the old `add_to_zshrc` helper.
- Retry cask installs after a targeted `brew update` when Homebrew metadata is stale, with clearer cask install/skip logs.
- Rename the GitHub Actions workflow from `lint` to `ci` because it also runs macOS smoke setup.
- Install Codex and `mcp-grafana` during work setup.
- Add empty-safe Grafana env placeholders to `~/.zshrc`: `GRAFANA_URL` and `GRAFANA_SERVICE_ACCOUNT_TOKEN`.
- Add missing MCP blocks to `~/.codex/config.toml` for Grafana, Datadog, and Channel Teamchat without overwriting existing entries.
- Run `codex mcp login datadog` and `codex mcp login channel-teamchat` during interactive work setup.

## Notes

Claude Code is already installed in `work_setup.sh`. I kept Codex in the same work-only layer because these MCP defaults are work-specific observability/teamchat tools. If we want Codex for personal machines too, I would split only the Codex cask install into `setup.sh` and leave these MCP blocks in `work_setup.sh`.

## Verification

- `/bin/bash -n common.sh setup.sh work_setup.sh`
- `for f in *.sh; do /bin/bash -n "$f" || exit 1; done`
- `shellcheck --severity=warning --exclude=SC2016 *.sh`
