### PR TITLE
feat: add Neovim + LazyVim + avante.nvim setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/common.sh -o common.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/system_setup.sh -o system_setup.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/interactive_setup.sh -o interactive_setup.sh && \
+curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/nvim_setup.sh -o nvim_setup.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/setup.sh -o setup.sh && \
 bash setup.sh
 ```
@@ -16,6 +17,7 @@ bash setup.sh
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/common.sh -o common.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/system_setup.sh -o system_setup.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/interactive_setup.sh -o interactive_setup.sh && \
+curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/nvim_setup.sh -o nvim_setup.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/setup.sh -o setup.sh && \
 curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/work_setup.sh -o work_setup.sh && \
 bash work_setup.sh

--- a/common.sh
+++ b/common.sh
@@ -77,7 +77,7 @@ cleanup_downloads() {
         return 0
     fi
     echo "🧹 Cleaning up downloaded scripts..."
-    rm -f "$dir"/{common,system_setup,interactive_setup,setup,work_setup}.sh
+    rm -f "$dir"/{common,system_setup,interactive_setup,setup,work_setup,nvim_setup}.sh
 }
 
 # ============================================

--- a/nvim/lua/plugins/avante.lua
+++ b/nvim/lua/plugins/avante.lua
@@ -1,0 +1,52 @@
+-- avante.nvim — Cursor 스타일 AI 어시스턴트 (LazyVim plugin override)
+-- 프로바이더/API 키는 의도적으로 미설정 (개인 셋업 기본값).
+-- 사용하려면 opts.provider 와 providers 를 채운 뒤 nvim 재시작. 예시:
+--   opts = {
+--     provider = "claude",
+--     providers = {
+--       claude = {
+--         endpoint = "https://api.anthropic.com",
+--         model = "claude-sonnet-4-6",
+--         api_key_name = "ANTHROPIC_API_KEY", -- 해당 키가 담긴 env 이름
+--       },
+--     },
+--   }
+-- 사용법: :AvanteAsk 로 대화, :AvanteToggle 로 패널 토글
+return {
+  "yetone/avante.nvim",
+  event = "VeryLazy",
+  version = false, -- 항상 최신 (avante 는 자주 바뀜)
+  -- prebuilt 바이너리 다운로드. 소스 빌드를 원하면:
+  --   build = "make BUILD_FROM_SOURCE=true"  (rust 필요)
+  build = "make",
+  opts = {
+    -- provider = "claude",  -- 사용 시 위 예시처럼 채우기
+  },
+  dependencies = {
+    "nvim-treesitter/nvim-treesitter",
+    "nvim-lua/plenary.nvim",
+    "MunifTanjim/nui.nvim",
+    -- 선택 의존성
+    "nvim-mini/mini.pick", -- file selector
+    "stevearc/dressing.nvim",
+    "folke/snacks.nvim",
+    {
+      -- 클립보드 이미지 붙여넣기
+      "HakonHarnes/img-clip.nvim",
+      event = "VeryLazy",
+      opts = {
+        default = {
+          embed_image_as_base64 = false,
+          prompt_for_file_name = false,
+          drag_and_drop = { insert_mode = true },
+        },
+      },
+    },
+    {
+      -- 마크다운/응답 렌더링
+      "MeanderingProgrammer/render-markdown.nvim",
+      opts = { file_types = { "markdown", "Avante" } },
+      ft = { "markdown", "Avante" },
+    },
+  },
+}

--- a/nvim_setup.sh
+++ b/nvim_setup.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# ============================================
+# Neovim + LazyVim + avante.nvim (비대면)
+# - setup.sh 에서 source 로 호출 (common.sh 헬퍼가 이미 스코프에 있음)
+# - 기존 .vimrc(클래식 Vim) 세팅과는 별개로 공존
+# ============================================
+
+NVIM_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "🧠 Setting up Neovim + LazyVim..."
+
+# ============================================
+# Dependencies
+# - C 컴파일러/make 는 Xcode CLT 가 이미 제공 (treesitter 컴파일용)
+# ============================================
+brew_install neovim
+brew_install ripgrep   # Telescope live-grep
+brew_install fd        # Telescope find files
+brew_install lazygit   # LazyVim git UI 통합
+brew_install_cask font-jetbrains-mono-nerd-font  # 아이콘 글리프
+
+# ============================================
+# LazyVim 부트스트랩
+# - ~/.config/nvim 이 비어있을 때만 starter 클론 (기존 설정 보존)
+# ============================================
+NVIM_CONFIG="$HOME/.config/nvim"
+if [[ ! -e "$NVIM_CONFIG/init.lua" ]]; then
+    echo "  ↳ Cloning LazyVim starter..."
+    mkdir -p "$(dirname "$NVIM_CONFIG")"
+    git clone --depth 1 https://github.com/LazyVim/starter "$NVIM_CONFIG"
+    rm -rf "$NVIM_CONFIG/.git"
+else
+    echo "  ↳ ~/.config/nvim 이미 존재 — starter 클론 스킵"
+fi
+
+# ============================================
+# avante.nvim plugin spec 배치
+# - git 체크아웃이면 저장소 파일 사용, 다운로드 모드면 raw GitHub 에서 curl
+#   (PR CI 에서 아직 master 에 없는 파일을 404 로 받는 문제 방지)
+# ============================================
+AVANTE_DEST="$NVIM_CONFIG/lua/plugins/avante.lua"
+AVANTE_SRC="$NVIM_SCRIPT_DIR/nvim/lua/plugins/avante.lua"
+if [[ -f "$AVANTE_DEST" ]]; then
+    # 로컬에서 프로바이더(예: 사내 게이트웨이)를 직접 설정해 둘 수 있으므로 덮어쓰지 않음
+    echo "  ↳ avante.lua 이미 존재 — 배치 스킵 (로컬 설정 보존)"
+else
+    mkdir -p "$(dirname "$AVANTE_DEST")"
+    if [[ -f "$AVANTE_SRC" ]]; then
+        cp "$AVANTE_SRC" "$AVANTE_DEST"
+        echo "  ↳ avante.lua 배치 (로컬)"
+    else
+        curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/nvim/lua/plugins/avante.lua -o "$AVANTE_DEST"
+        echo "  ↳ avante.lua 배치 (curl)"
+    fi
+fi
+
+echo "✅ Neovim + LazyVim + avante ready"
+echo "  ↳ 첫 nvim 실행 시 LazyVim 이 플러그인을 자동 설치합니다 (avante 빌드 포함)"
+echo "  ↳ avante 프로바이더/API 키는 미설정 — $AVANTE_DEST 참고"

--- a/setup.sh
+++ b/setup.sh
@@ -76,6 +76,11 @@ curl -fsSL https://raw.githubusercontent.com/morhetz/gruvbox/master/colors/gruvb
 echo "✅ Vim ready"
 
 # ============================================
+# Neovim + LazyVim + avante.nvim
+# ============================================
+source "$SCRIPT_DIR/nvim_setup.sh"
+
+# ============================================
 # mise (Runtime Version Manager)
 # ============================================
 echo "🔄 Checking mise..."


### PR DESCRIPTION
## What

Adds Neovim provisioning to the personal Mac setup, alongside the existing classic Vim config (both coexist).

## Changes

- **`nvim_setup.sh`** (new module, sourced by `setup.sh`):
  - `brew_install`: `neovim`, `ripgrep`, `fd`, `lazygit` + cask `font-jetbrains-mono-nerd-font`
  - Bootstraps the LazyVim starter into `~/.config/nvim` **only if `init.lua` is absent** (idempotent — won't clobber an existing config)
  - Places `avante.lua` into `~/.config/nvim/lua/plugins/` **only if it doesn't already exist**, so a locally-customized provider config is preserved on re-run. Uses the repo file on a git checkout, else `curl` from raw GitHub (avoids PR-CI 404 on not-yet-merged files — same local-vs-download pattern as `cleanup_downloads`).
- **`nvim/lua/plugins/avante.lua`** (new): avante.nvim plugin spec. **Provider intentionally unset** — this is a personal-setup repo, so no AI gateway is baked in; a commented example shows how to wire one up. `build = "make"` (prebuilt binaries).
- **`setup.sh`**: `source nvim_setup.sh` right after the Vim section.
- **`common.sh`**: add `nvim_setup` to the `cleanup_downloads` list.
- **`README.md`**: add `nvim_setup.sh` to both download one-liners.

## Verification

- `bash -n` (system bash 3.2) parses cleanly on all `*.sh`.
- Applied locally end-to-end: fd/lazygit installed, LazyVim sync installed + built avante (prebuilt `v0.1.2`), avante loads without errors. (CI `smoke-macos` re-validates by running `setup.sh`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)