### PR TITLE
feat: add im-select.nvim with terminal-compatible config

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -69,6 +69,21 @@ brew_install_cask() {
     }
 }
 
+brew_tap_and_install() {
+    local tap="$1"
+    local formula="$2"
+
+    if command -v "$formula" &>/dev/null; then
+        echo "  ↳ $formula already installed"
+        return 0
+    fi
+
+    echo "  ↳ Installing $formula from $tap..."
+    brew tap "$tap"
+    brew trust "$tap" 2>/dev/null || true
+    brew install "$formula"
+}
+
 # 다운받아 실행한 .sh 파일들을 끝나면 정리
 # git 체크아웃에서 돌릴 때는 작업 트리를 건드리면 안 되므로 스킵
 cleanup_downloads() {

--- a/nvim/lua/plugins/im-select.lua
+++ b/nvim/lua/plugins/im-select.lua
@@ -1,0 +1,17 @@
+-- im-select.nvim — 자동 입력 소스 전환 (insert mode ↔ normal mode)
+-- normal mode 진입 시 자동으로 영문 입력으로 전환하고,
+-- insert mode 재진입 시 이전 입력 소스로 복원.
+-- 한글, 일본어, 중국어 등 모든 입력 소스를 자동 감지하여 처리.
+return {
+  "keaising/im-select.nvim",
+  event = "VeryLazy",
+  opts = {
+    -- macOS 기본 영문 입력 소스 (normal mode 에서 사용할 기본값)
+    default_im_select = "com.apple.keylayout.ABC",
+    -- im-select 바이너리 경로 (Homebrew 로 설치)
+    default_command = "/opt/homebrew/bin/im-select",
+    -- 모드 전환 시 자동으로 입력 소스 전환 활성화
+    set_default_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
+    set_previous_events = { "InsertEnter" },
+  },
+}

--- a/nvim/lua/plugins/im-select.lua
+++ b/nvim/lua/plugins/im-select.lua
@@ -1,17 +1,11 @@
--- im-select.nvim — 자동 입력 소스 전환 (insert mode ↔ normal mode)
--- normal mode 진입 시 자동으로 영문 입력으로 전환하고,
--- insert mode 재진입 시 이전 입력 소스로 복원.
--- 한글, 일본어, 중국어 등 모든 입력 소스를 자동 감지하여 처리.
+-- im-select.nvim — normal mode 진입 시 자동으로 영문 입력으로 전환
 return {
   "keaising/im-select.nvim",
   event = "VeryLazy",
   opts = {
-    -- macOS 기본 영문 입력 소스 (normal mode 에서 사용할 기본값)
     default_im_select = "com.apple.keylayout.ABC",
-    -- im-select 바이너리 경로 (Homebrew 로 설치)
     default_command = "/opt/homebrew/bin/im-select",
-    -- 모드 전환 시 자동으로 입력 소스 전환 활성화
-    set_default_events = { "VimEnter", "FocusGained", "InsertLeave", "CmdlineLeave" },
-    set_previous_events = { "InsertEnter" },
+    set_default_events = { "InsertLeave", "CmdlineLeave", "TermLeave" },
+    set_previous_events = {},
   },
 }

--- a/nvim_setup.sh
+++ b/nvim_setup.sh
@@ -17,6 +17,7 @@ brew_install neovim
 brew_install ripgrep   # Telescope live-grep
 brew_install fd        # Telescope find files
 brew_install lazygit   # LazyVim git UI 통합
+brew_install im-select # 입력 소스 자동 전환 (im-select.nvim)
 brew_install_cask font-jetbrains-mono-nerd-font  # 아이콘 글리프
 
 # ============================================
@@ -34,17 +35,19 @@ else
 fi
 
 # ============================================
-# avante.nvim plugin spec 배치
+# plugin spec 배치 (avante.nvim, im-select.nvim)
 # - git 체크아웃이면 저장소 파일 사용, 다운로드 모드면 raw GitHub 에서 curl
 #   (PR CI 에서 아직 master 에 없는 파일을 404 로 받는 문제 방지)
 # ============================================
+mkdir -p "$NVIM_CONFIG/lua/plugins"
+
+# avante.nvim
 AVANTE_DEST="$NVIM_CONFIG/lua/plugins/avante.lua"
 AVANTE_SRC="$NVIM_SCRIPT_DIR/nvim/lua/plugins/avante.lua"
 if [[ -f "$AVANTE_DEST" ]]; then
     # 로컬에서 프로바이더(예: 사내 게이트웨이)를 직접 설정해 둘 수 있으므로 덮어쓰지 않음
     echo "  ↳ avante.lua 이미 존재 — 배치 스킵 (로컬 설정 보존)"
 else
-    mkdir -p "$(dirname "$AVANTE_DEST")"
     if [[ -f "$AVANTE_SRC" ]]; then
         cp "$AVANTE_SRC" "$AVANTE_DEST"
         echo "  ↳ avante.lua 배치 (로컬)"
@@ -54,6 +57,22 @@ else
     fi
 fi
 
-echo "✅ Neovim + LazyVim + avante ready"
+# im-select.nvim
+IMSELECT_DEST="$NVIM_CONFIG/lua/plugins/im-select.lua"
+IMSELECT_SRC="$NVIM_SCRIPT_DIR/nvim/lua/plugins/im-select.lua"
+if [[ -f "$IMSELECT_DEST" ]]; then
+    echo "  ↳ im-select.lua 이미 존재 — 배치 스킵 (로컬 설정 보존)"
+else
+    if [[ -f "$IMSELECT_SRC" ]]; then
+        cp "$IMSELECT_SRC" "$IMSELECT_DEST"
+        echo "  ↳ im-select.lua 배치 (로컬)"
+    else
+        curl -fsSL https://raw.githubusercontent.com/Clsan/setup/master/nvim/lua/plugins/im-select.lua -o "$IMSELECT_DEST"
+        echo "  ↳ im-select.lua 배치 (curl)"
+    fi
+fi
+
+echo "✅ Neovim + LazyVim + avante + im-select ready"
 echo "  ↳ 첫 nvim 실행 시 LazyVim 이 플러그인을 자동 설치합니다 (avante 빌드 포함)"
 echo "  ↳ avante 프로바이더/API 키는 미설정 — $AVANTE_DEST 참고"
+echo "  ↳ im-select: normal mode 진입 시 자동으로 영문 입력으로 전환"

--- a/nvim_setup.sh
+++ b/nvim_setup.sh
@@ -17,17 +17,8 @@ brew_install neovim
 brew_install ripgrep   # Telescope live-grep
 brew_install fd        # Telescope find files
 brew_install lazygit   # LazyVim git UI 통합
+brew_tap_and_install daipeihust/tap im-select  # 입력 소스 자동 전환 (im-select.nvim)
 brew_install_cask font-jetbrains-mono-nerd-font  # 아이콘 글리프
-
-# im-select (입력 소스 자동 전환)
-if ! command -v im-select &>/dev/null; then
-    echo "  ↳ Installing im-select..."
-    brew tap daipeihust/tap
-    brew trust daipeihust/tap 2>/dev/null || true
-    brew install im-select
-else
-    echo "  ↳ im-select already installed"
-fi
 
 # ============================================
 # LazyVim 부트스트랩

--- a/nvim_setup.sh
+++ b/nvim_setup.sh
@@ -17,8 +17,17 @@ brew_install neovim
 brew_install ripgrep   # Telescope live-grep
 brew_install fd        # Telescope find files
 brew_install lazygit   # LazyVim git UI 통합
-brew_install im-select # 입력 소스 자동 전환 (im-select.nvim)
 brew_install_cask font-jetbrains-mono-nerd-font  # 아이콘 글리프
+
+# im-select (입력 소스 자동 전환)
+if ! command -v im-select &>/dev/null; then
+    echo "  ↳ Installing im-select..."
+    brew tap daipeihust/tap
+    brew trust daipeihust/tap 2>/dev/null || true
+    brew install im-select
+else
+    echo "  ↳ im-select already installed"
+fi
 
 # ============================================
 # LazyVim 부트스트랩

--- a/nvim_setup.sh
+++ b/nvim_setup.sh
@@ -72,6 +72,11 @@ else
     fi
 fi
 
+# keymaps.lua — terminal mode 에서 Esc Esc 로 normal 모드로 이동
+KEYMAPS_DEST="$NVIM_CONFIG/lua/config/keymaps.lua"
+append_line_if_missing "$KEYMAPS_DEST" 'vim.keymap.set("t", "<Esc><Esc>", "<C-\\><C-N>", { desc = "Exit terminal mode" })'
+echo "  ↳ keymaps.lua terminal keymap 확인/추가"
+
 echo "✅ Neovim + LazyVim + avante + im-select ready"
 echo "  ↳ 첫 nvim 실행 시 LazyVim 이 플러그인을 자동 설치합니다 (avante 빌드 포함)"
 echo "  ↳ avante 프로바이더/API 키는 미설정 — $AVANTE_DEST 참고"


### PR DESCRIPTION
## Summary

- **`common.sh`**: add `brew_tap_and_install` helper for tapped formulae
- **`nvim_setup.sh`**:
  - Install `im-select` via `daipeihust/tap`
  - Deploy `im-select.lua` plugin spec (same copy-if-missing pattern as avante)
  - Idempotently append double-Esc → normal mode keymap to `keymaps.lua` via `append_line_if_missing`
- **`nvim/lua/plugins/im-select.lua`**: new plugin spec
  - Switches IM to ABC on `InsertLeave`, `CmdlineLeave`, `TermLeave`
  - `TermLeave` ensures IM switches correctly when exiting both snacks terminal and raw `:terminal` buffers
  - `set_previous_events = {}` prevents Korean IME from being restored inside terminal buffers (which caused Escape to be intercepted by the IME)

## Test plan

- [ ] Run `nvim_setup.sh` on a fresh machine — im-select installed and configured
- [ ] Re-run `nvim_setup.sh` — no duplicates, all steps skipped idempotently
- [ ] In nvim, leave insert mode with Korean active → IM switches to ABC
- [ ] Open snacks terminal (`<leader>ft`), double-Esc → Normal mode, IM → ABC
- [ ] Open raw terminal (`:vsplit | terminal`), double-Esc → Normal mode, IM → ABC

🤖 Generated with [Claude Code](https://claude.com/claude-code)